### PR TITLE
Add text_to_phonemes function for IPA transcription

### DIFF
--- a/examples/text_to_phonemes_example.py
+++ b/examples/text_to_phonemes_example.py
@@ -1,0 +1,18 @@
+import espeak_ng
+
+'''
+This example demonstrates how to use text_to_phonemes to convert text to phonemes, without synthetizing the sound.
+'''
+
+def main():
+    espeak_ng.initialize()
+    espeak_ng.set_voice_by_properties(name="pl")
+    USE_IPA = 0x02
+    SEPARATOR = ord('_') << 8
+    phonemes = espeak_ng.text_to_phonemes("żółw", phonememode=USE_IPA | SEPARATOR)
+    print(phonemes)
+    assert(phonemes == 'ʒ_ˈu_w_f')
+
+if __name__ == "__main__":
+    main()
+

--- a/src/espeak_ng/extension/_espeakngmodule.c
+++ b/src/espeak_ng/extension/_espeakngmodule.c
@@ -349,6 +349,29 @@ espeak_ng_py_SetSynthCallback(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+espeak_ng_py_TextToPhonemes(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    const char *text;
+    int textmode = espeakCHARS_AUTO;
+    int phonememode = espeakPHONEMES_IPA;
+
+    static const char *kwlist[] = {"text", "textmode", "phonememode", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|ii", kwlist,
+                                     &text, &textmode, &phonememode))
+        return NULL;
+
+    const char *phonemes = espeak_TextToPhonemes((const void **)&text, textmode, phonememode);
+
+    if (phonemes == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "espeak_TextToPhonemes returned NULL");
+        return NULL;
+    }
+
+    return Py_BuildValue("s", phonemes);
+}
+
 // ***********************************************************
 // Python Module
 // ***********************************************************
@@ -360,6 +383,7 @@ static PyMethodDef EspeakNgMethods[] = {
     {"set_synth_callback", espeak_ng_py_SetSynthCallback, METH_VARARGS, "set synth callback"},
     {"synth", espeak_ng_py_Synth, METH_VARARGS | METH_KEYWORDS, "synthesize text to speech"},
     {"list_voices", espeak_ng_py_ListVoices, METH_VARARGS, "list all available voices"},
+    {"text_to_phonemes", espeak_ng_py_TextToPhonemes, METH_VARARGS | METH_KEYWORDS, "convert text to IPA phonemes"},
     {NULL, NULL, 0, NULL} // Sentinel
 };
 


### PR DESCRIPTION
This PR adds a wrapper for espeak_TextToPhonemes, enabling IPA phonetic transcription.

Usage:
```
import espeak_ng
espeak_ng.initialize()
espeak_ng.set_voice_by_properties(name="pl")
print(espeak_ng.text_to_phonemes("żółw", phonememode=(0x02 | (ord('_') << 8))))
```

This should display:
```
ʒ_ˈu_w_f
```